### PR TITLE
find and replace app & module names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-webauthn_live_component-*.tar
+webauthn_components-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# WebAuthnLiveComponent
+# WebAuthnComponents
 
 A drop-in LiveComponent for password-less authentication.
 
 ### 🚨 Status 🚨
 
-This package is a **work in progress**, and it is in early alpha status. Feel free to experiment with this package and contribute feedback through [GitHub discussions](https://github.com/liveshowy/webauthn_live_component/discussions).
+This package is a **work in progress**, and it is in early alpha status. Feel free to experiment with this package and contribute feedback through [GitHub discussions](https://github.com/liveshowy/webauthn_components/discussions).
 
-Please **do not use WebAuthnLiveComponent in a production environment** until it has completed _beta_ testing.
+Please **do not use WebAuthnComponents in a production environment** until it has completed _beta_ testing.
 
 ## Roadmap
 
-View the planned work for this repo in the public [WebAuthnLiveComponent v1](https://github.com/orgs/liveshowy/projects/3/views/1) project on GitHub.
+View the planned work for this repo in the public [WebAuthnComponents v1](https://github.com/orgs/liveshowy/projects/3/views/1) project on GitHub.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ During the beta phase, generators will be added to streamline initial setup, inc
    - `mix phx.gen.context --binary-id Authentication UserKey user_keys key_id:binary label last_used:utc_datetime public_key:binary user_id:references:users`
 1. Update `UserKey` schema (TODO)
    - Add default value to the `label` field
-   - Update the `public_key` field to use `WebAuthnLiveComponent.CoseKey` as its type
+   - Update the `public_key` field to use `WebAuthnComponents.CoseKey` as its type
    - Add `new_changeset/2` & `update_changeset/2` (TODO)
 1. Run Mix task to create `user_tokens` schema & migration
    - `mix phx.gen.context --binary-id Authentication UserToken user_tokens user_id:references:users token:binary context`
@@ -36,19 +36,19 @@ During the beta phase, generators will be added to streamline initial setup, inc
 
 ### Installation
 
-Add `webauthn_live_component` to your list of dependencies in `mix.exs`:
+Add `webauthn_components` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:webauthn_live_component, "~> 0.1.0"}
+    {:webauthn_components, "~> 0.1.0"}
   ]
 end
 ```
 
 ### Usage
 
-See `WebAuthnLiveComponent` for detailed usage instructions.
+See `WebAuthnComponents` for detailed usage instructions.
 
 ## WebAuthn & Passkeys
 

--- a/lib/button.ex
+++ b/lib/button.ex
@@ -1,4 +1,4 @@
-defmodule WebAuthnLiveComponent.Button do
+defmodule WebAuthnComponents.Button do
   @moduledoc """
   Component which renders a basic HTML button.
   """

--- a/lib/cose_key.ex
+++ b/lib/cose_key.ex
@@ -1,4 +1,4 @@
-defmodule WebAuthnLiveComponent.CoseKey do
+defmodule WebAuthnComponents.CoseKey do
   @moduledoc """
   Custom type for WebAuthn cose keys.
   """

--- a/lib/passkey_component.ex
+++ b/lib/passkey_component.ex
@@ -1,4 +1,4 @@
-defmodule WebAuthnLiveComponent.PasskeyComponent do
+defmodule WebAuthnComponents.PasskeyComponent do
   @moduledoc """
   LiveComponent for interacting with Passkeys.
 

--- a/lib/webauthn_live_component.ex
+++ b/lib/webauthn_live_component.ex
@@ -1,11 +1,11 @@
-defmodule WebAuthnLiveComponent do
+defmodule WebAuthnComponents do
   @moduledoc """
   A LiveComponent for passwordless authentication via WebAuthn.
   """
   use Phoenix.LiveComponent
   import Phoenix.HTML.Form
   alias Ecto.Changeset
-  alias WebAuthnLiveComponent.Button
+  alias WebAuthnComponents.Button
 
   # prop app, :atom, required: true
   # prop changeset, :struct, default: build_changeset()
@@ -98,7 +98,7 @@ defmodule WebAuthnLiveComponent do
 
   ## Client-Side Events
 
-  `WebAuthnLiveComponent` uses a Javascript (JS) hook to interact with the client-side WebAuthn API.
+  `WebAuthnComponents` uses a Javascript (JS) hook to interact with the client-side WebAuthn API.
 
   The following events are triggered by the WebAuthn JS hook:
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,19 +1,19 @@
-defmodule WebAuthnLiveComponent.MixProject do
+defmodule WebAuthnComponents.MixProject do
   use Mix.Project
 
   # Don't forget to change the version in `package.json`
-  @source_url "https://github.com/liveshowy/webauthn_live_component"
+  @source_url "https://github.com/liveshowy/webauthn_components"
   @version "0.2.2"
 
   def project do
     [
-      app: :webauthn_live_component,
+      app: :webauthn_components,
       deps: deps(),
       description: description(),
       docs: docs(),
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
-      name: "WebAuthnLiveComponent",
+      name: "WebAuthnComponents",
       package: package(),
       start_permanent: Mix.env() == :prod,
       version: @version
@@ -49,7 +49,7 @@ defmodule WebAuthnLiveComponent.MixProject do
       main: "readme",
       name: "WebAuthn LiveComponent",
       source_ref: "v#{@version}",
-      canonical: "http://hexdocs.pm/webauthn_live_component",
+      canonical: "http://hexdocs.pm/webauthn_components",
       source_url: @source_url,
       extras: ["README.md"]
     ]

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webauthn_live_component",
+  "name": "webauthn_components",
   "version": "0.1.2",
   "main": "./priv/static/passkey_hook.js",
   "repository": {},

--- a/test/webauthn_live_component_test.exs
+++ b/test/webauthn_live_component_test.exs
@@ -1,12 +1,12 @@
-defmodule WebAuthnLiveComponentTest do
+defmodule WebAuthnComponentsTest do
   @moduledoc false
   use ComponentCase
   import Phoenix.LiveView.Helpers
-  doctest WebAuthnLiveComponent
+  doctest WebAuthnComponents
 
   test "socket assigns include a valid changeset on mount" do
     socket = %Phoenix.LiveView.Socket{}
-    assert {:ok, component} = WebAuthnLiveComponent.mount(socket)
+    assert {:ok, component} = WebAuthnComponents.mount(socket)
     changeset = component.assigns.changeset
     assert %Ecto.Changeset{} = changeset
     assert Enum.empty?(changeset.errors)
@@ -14,9 +14,9 @@ defmodule WebAuthnLiveComponentTest do
   end
 
   test "a form is rendered" do
-    live_component = live_component(WebAuthnLiveComponent, id: "test_form")
+    live_component = live_component(WebAuthnComponents, id: "test_form")
     assert %Phoenix.LiveView.Component{component: component, assigns: assigns} = live_component
     assert %Phoenix.LiveView.Rendered{} = component.render(assigns)
-    assert render_component(WebAuthnLiveComponent, id: "test_form") =~ "username"
+    assert render_component(WebAuthnComponents, id: "test_form") =~ "username"
   end
 end


### PR DESCRIPTION
# Overview

Resolves #35 

After receiving feedback about using WebAuthn for MFA, and after considering flows for adding multiple keys to user accounts, the name `WebAuthnLiveComponents` started to feel like a bad fit for this repo. To provide more flexibility, the repo and hex package have been renamed to `WebAuthnComponents`.

## Context

[Elixir Forum Thread](https://elixirforum.com/t/webauthnlivecomponent-passwordless-auth-for-liveview-apps/49941/16?u=type1fool)

## Changes

- Replaced all instances of `webauthn_live_component` with `webauthn_components`
- Replaced all instances of `WebAuthnLiveComponent` with `WebAuthnComponents`
