### PR TITLE
Fixes

### DIFF
--- a/lib/webauthn_components/authentication_component.ex
+++ b/lib/webauthn_components/authentication_component.ex
@@ -67,21 +67,22 @@ defmodule WebauthnComponents.AuthenticationComponent do
     """
   end
 
-  def update(%{challenge: challenge, attestation: attestation, user_key: user_key} = assigns, socket) do
+  def update(%{user_key: user_key} = assigns, socket) do
+    %{challenge: challenge, attestation: attestation} = socket.assigns
+
     %{
       authenticator_data: authenticator_data,
       client_data_array: client_data_array,
-      # raw_id: raw_id,
       signature: signature,
-      # user_handle: user_handle
     } = attestation
 
     %{
       key_id: key_id,
-      # user_handle: user_handle,
-      # public_key: public_key,
-      user: user,
+      public_key: public_key,
+      user: user
     } = user_key
+
+    credentials = [{key_id, public_key}]
 
     wax_response = Wax.authenticate(
       key_id,
@@ -89,9 +90,8 @@ defmodule WebauthnComponents.AuthenticationComponent do
       signature,
       client_data_array,
       challenge,
-      [user_key]
+      credentials
     )
-    |> IO.inspect(label: :wax_authenticate)
 
     case wax_response do
       {:ok, _authenticator_data} ->
@@ -118,8 +118,7 @@ defmodule WebauthnComponents.AuthenticationComponent do
       Wax.new_authentication_challenge(
         origin: endpoint.url,
         rp_id: :auto,
-        user_verification: "preferred",
-        allow_credentials: []
+        user_verification: "preferred"
       )
 
     challenge_data = %{

--- a/lib/webauthn_components/authentication_component.ex
+++ b/lib/webauthn_components/authentication_component.ex
@@ -91,6 +91,7 @@ defmodule WebauthnComponents.AuthenticationComponent do
       challenge,
       [user_key]
     )
+    |> IO.inspect(label: :wax_authenticate)
 
     case wax_response do
       {:ok, _authenticator_data} ->

--- a/lib/webauthn_components/cose_key.ex
+++ b/lib/webauthn_components/cose_key.ex
@@ -43,6 +43,13 @@ defmodule WebauthnComponents.CoseKey do
     end
   end
 
+  def cast(value) when is_binary(value) do
+    case CBOR.decode(value) do
+      {:ok, _decoded_value, ""} -> value
+      {:error, _error} -> :error
+    end
+  end
+
   def cast(_), do: :error
 
   def load(data) when is_binary(data) do
@@ -57,6 +64,13 @@ defmodule WebauthnComponents.CoseKey do
 
   def dump(value) when is_map(value) do
     {:ok, CBOR.encode(value)}
+  end
+
+  def dump(value) when is_binary(value) do
+    case CBOR.decode(value) do
+      {:ok, _decoded_value, ""} -> {:ok, value}
+      {:error, _error} -> :error
+    end
   end
 
   def dump(value), do: {:ok, value}

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule WebauthnComponents.MixProject do
 
   # Don't forget to change the version in `package.json`
   @source_url "https://github.com/liveshowy/webauthn_components"
-  @version "0.3.2"
+  @version "0.3.3"
 
   def project do
     [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webauthn_components",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "./priv/static/main.js",
   "repository": {},
   "files": [

--- a/priv/static/registration_hook.js
+++ b/priv/static/registration_hook.js
@@ -10,7 +10,6 @@ const RegistrationHook = {
   },
 
   async handleRegistration(event, context) {
-    console.log(event);
     try {
       const {
         attestation,

--- a/priv/static/token_hook.js
+++ b/priv/static/token_hook.js
@@ -20,7 +20,6 @@ const TokenHook = {
   storeToken({ token }, context) {
     try {
       window.sessionStorage.setItem("userToken", token);
-      console.log(token, sessionStorage);
       console.info(`Stored user token`);
       context.pushEventTo(context.el, "token-stored", { token });
     } catch (error) {
@@ -32,7 +31,6 @@ const TokenHook = {
   clearToken(context) {
     try {
       window.sessionStorage.removeItem("userToken");
-      console.log(sessionStorage);
       console.info(`Cleared user token`);
       context.pushEventTo(context.el, "token-cleared", { token: null });
     } catch (error) {


### PR DESCRIPTION
# Overview

This PR adds an update callback implementation to `WebauthnComponents.AuthenticationComponent`, which adds proper validation of the challenge and attestation against a `user_key` provided by the parent application.

## Changes

- Added `update/2` implementation
- Added `Wax.authenticate/6` call
- Updated `WebauthnComponents.CoseKey`
- Removed `console.log()` calls

## Tests

```elixir
mix test
...
Finished in 0.1 seconds (0.1s async, 0.00s sync)
16 tests, 0 failures

Randomized with seed 840688
```
