### PR TITLE
Accept User Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ def deps do
 end
 ```
 
-### Usage
+## Usage
 
 See [USAGE.md](./USAGE.md) for detailed usage instructions.
 
@@ -56,6 +56,16 @@ See [USAGE.md](./USAGE.md) for detailed usage instructions.
 `WebauthnComponents` contains a few modular components which may be combined to detect passkey support, register new keys, authenticate keys for existing users, and manage session tokens in the client.
 
 See module documentation for each component for more detailed descriptions.
+
+## Cross-Device Authentication
+
+When a user attempts to authenticate on a device where their Passkey is **not** stored, they may scan a QR code to use a cloud-sync'd Passkey.
+
+### Example
+
+Imagine a user, Amal, registers a Passkey for example.com on their iPhone and it's stored in iCloud. When they attempt to sign into example.com on a non-Apple device or any browser which cannot access their OS keychain, they may choose to scan a QR code using their iPhone. Assuming the prompts on the iPhone are successful, the other device will be authenticated using the same web account which was initially registered on the iPhone.
+
+While this example refers to Apple's Passkey implementation, the process on other platforms may vary. Cross-device credential managers like 1Password may provide a more seamless flow for users who are not constrained to one OS or browser.
 
 #### Support Detection
 
@@ -157,10 +167,10 @@ sequenceDiagram
    Client->>AuthenticationComponent: "authenticate"
    AuthenticationComponent->>Client: "authentication-challenge"
    Client->>AuthenticationComponent: "authentication-attestation"
-   AuthenticationComponent->>ParentLiveView: `{:find_credentials, ...}`
+   AuthenticationComponent->>ParentLiveView: `{:find_credential, ...}`
 ```
 
-Once the parent LiveView receives the `{:find_credentials, ...}` message, it must lookup the user via the user's existing key. To keep the user signed in, the LiveView may [create a session token](#token-management), Base64-encode the token, and pass it to `TokenComponent` for persistence in the client's `sessionStorage`.
+Once the parent LiveView receives the `{:find_credential, ...}` message, it must lookup the user via the user's existing key. To keep the user signed in, the LiveView may [create a session token](#token-management), Base64-encode the token, and pass it to `TokenComponent` for persistence in the client's `sessionStorage`.
 
 ## WebAuthn & Passkeys
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -73,7 +73,7 @@ defmodule MyAppWeb.AuthLive do
     }
   end
 
-  def handle_info({:registration_successful, key_id: raw_id, public_key: public_key, user_handle: user_handle}, socket) do
+  def handle_info({:registration_successful, key_id: raw_id, public_key: public_key}, socket) do
     # Persist the user here.
   end
 

--- a/lib/webauthn_components/authentication_component.ex
+++ b/lib/webauthn_components/authentication_component.ex
@@ -6,7 +6,22 @@ defmodule WebauthnComponents.AuthenticationComponent do
 
   Authentication is the process of matching a registered key to an existing user.
 
+  With Passkeys, the user is presented with a native modal from the browser or OS.
+
+  - If the user has only one passkey registered to the application's origin URL, they will be prompted to confirm acceptance via biometric ID (touch, face, etc.), OS password, or an OS PIN.
+  - If multiple accounts are registered to the device for the origin URL, the user may select an account to use for the current session.
+
   See [USAGE.md](./USAGE.md) for example code.
+
+  ## Cross-Device Authentication
+
+  When a user attempts to authenticate on a device where their Passkey is **not** stored, they may scan a QR code to use a cloud-sync'd Passkey.
+
+  ### Example
+
+  Imagine a user, Amal, registers a Passkey for example.com on their iPhone and it's stored in iCloud. When they attempt to sign into example.com on a non-Apple device or any browser which cannot access their OS keychain, they may choose to scan a QR code using their iPhone. Assuming the prompts on the iPhone are successful, the other device will be authenticated using the same web account which was initially registered on the iPhone.
+
+  While this example refers to Apple's Passkey implementation, the process on other platforms may vary. Cross-device credential managers like 1Password may provide a more seamless flow for users who are not constrained to one OS or browser.
 
   ## Assigns
 

--- a/lib/webauthn_components/authentication_component.ex
+++ b/lib/webauthn_components/authentication_component.ex
@@ -24,8 +24,8 @@ defmodule WebauthnComponents.AuthenticationComponent do
 
   ## Messages
 
-  - `{:find_credentials, user_handle: user_handle}`
-    - `user_handle` is a raw binary representing the user id or random id stored in the credential during registration.
+  - `{:find_credentials, key_id: key_id}`
+    - `key_id` is a raw binary representing the id stored associated with the credential in both the client and server during registration.
     - The parent LiveView must successfully lookup the user with this data before storing a token and redirecting to another view.
   - `{:error, payload}`
     - `payload` contains the `message`, `name`, and `stack` returned by the browser upon timeout or other client-side errors.

--- a/lib/webauthn_components/authentication_component.ex
+++ b/lib/webauthn_components/authentication_component.ex
@@ -39,7 +39,7 @@ defmodule WebauthnComponents.AuthenticationComponent do
 
   ## Messages
 
-  - `{:find_credentials, key_id: key_id}`
+  - `{:find_credential, key_id: key_id}`
     - `key_id` is a raw binary representing the id stored associated with the credential in both the client and server during registration.
     - The parent LiveView must successfully lookup the user with this data before storing a token and redirecting to another view.
   - `{:error, payload}`
@@ -173,7 +173,7 @@ defmodule WebauthnComponents.AuthenticationComponent do
       type: type
     }
 
-    send(self(), {:find_credentials, key_id: raw_id})
+    send(self(), {:find_credential, key_id: raw_id})
 
     {
       :noreply,

--- a/lib/webauthn_components/authentication_component.ex
+++ b/lib/webauthn_components/authentication_component.ex
@@ -73,7 +73,7 @@ defmodule WebauthnComponents.AuthenticationComponent do
     %{
       authenticator_data: authenticator_data,
       client_data_array: client_data_array,
-      signature: signature,
+      signature: signature
     } = attestation
 
     %{
@@ -84,14 +84,15 @@ defmodule WebauthnComponents.AuthenticationComponent do
 
     credentials = [{key_id, public_key}]
 
-    wax_response = Wax.authenticate(
-      key_id,
-      authenticator_data,
-      signature,
-      client_data_array,
-      challenge,
-      credentials
-    )
+    wax_response =
+      Wax.authenticate(
+        key_id,
+        authenticator_data,
+        signature,
+        client_data_array,
+        challenge,
+        credentials
+      )
 
     case wax_response do
       {:ok, _authenticator_data} ->
@@ -103,7 +104,6 @@ defmodule WebauthnComponents.AuthenticationComponent do
         send(self(), {:authentication_failure, message: message})
         {:ok, assign(socket, assigns)}
     end
-
   end
 
   def update(assigns, socket) do
@@ -143,25 +143,22 @@ defmodule WebauthnComponents.AuthenticationComponent do
       "clientDataArray" => client_data_array,
       "rawId64" => raw_id_64,
       "signature64" => signature_64,
-      "type" => type,
-      "userHandle64" => user_handle_64
+      "type" => type
     } = payload
 
     authenticator_data = Base.decode64!(authenticator_data_64, padding: false)
     raw_id = Base.decode64!(raw_id_64, padding: false)
     signature = Base.decode64!(signature_64, padding: false)
-    user_handle = Base.decode64!(user_handle_64, padding: false)
 
     attestation = %{
       authenticator_data: authenticator_data,
       client_data_array: client_data_array,
       raw_id: raw_id,
       signature: signature,
-      type: type,
-      user_handle: user_handle
+      type: type
     }
 
-    send(self(), {:find_credentials, user_handle: user_handle})
+    send(self(), {:find_credentials, key_id: raw_id})
 
     {
       :noreply,

--- a/lib/webauthn_components/cose_key.ex
+++ b/lib/webauthn_components/cose_key.ex
@@ -19,7 +19,6 @@ defmodule WebauthnComponents.CoseKey do
     schema "user_keys" do
       field :label, :string, default: "default"
       field :key_id, :binary
-      field :user_handle, :binary
       field :public_key, CoseKey
       belongs_to :user, User
       field :last_used, :utc_datetime

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -4,7 +4,7 @@ defmodule WebauthnComponents.RegistrationComponent do
 
   > Registration = Sign Up
 
-  Registration is the process of creating and associating a new key with a user account. Depending on your implementation, a new user may register a new account using only a Passkey, which does not require username or email.
+  Registration is the process of creating and associating a new key with a user account.
 
   Existing users may also register additional keys for backup, survivorship, sharing, or other purposes. Your application may set limits on how many keys are associated with an account based on business concerns.
 

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -64,11 +64,16 @@ defmodule WebauthnComponents.RegistrationComponent do
   end
 
   def update(%{webauthn_user: webauthn_user}, socket) do
-    {
-      :ok,
-      socket
-      |> assign(:webauthn_user, webauthn_user)
-    }
+    if is_struct(webauthn_user, WebauthnUser) do
+      {
+        :ok,
+        socket
+        |> assign(:webauthn_user, webauthn_user)
+      }
+    else
+      send(self(), {:invalid_webauthn_user, webauthn_user})
+      {:ok, socket}
+    end
   end
 
   def update(assigns, socket) do

--- a/lib/webauthn_components/webauthn_user.ex
+++ b/lib/webauthn_components/webauthn_user.ex
@@ -10,4 +10,16 @@ defmodule WebauthnComponents.WebauthnUser do
           name: String.t(),
           display_name: String.t()
         }
+
+  defimpl Jason.Encoder, for: __MODULE__ do
+    def encode(struct, opts) do
+      map =
+        struct
+        |> Map.from_struct()
+        |> Map.put(:displayName, struct.display_name)
+        |> Map.delete(:display_name)
+
+      Jason.Encode.map(map, opts)
+    end
+  end
 end

--- a/lib/webauthn_components/webauthn_user.ex
+++ b/lib/webauthn_components/webauthn_user.ex
@@ -1,0 +1,13 @@
+defmodule WebauthnComponents.WebauthnUser do
+  @moduledoc """
+  Struct representing required fields used by the WebAuthn API.
+  """
+  @enforce_keys [:id, :name, :display_name]
+  defstruct [:id, :name, :display_name]
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          name: String.t(),
+          display_name: String.t()
+        }
+end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule WebauthnComponents.MixProject do
 
   # Don't forget to change the version in `package.json`
   @source_url "https://github.com/liveshowy/webauthn_components"
-  @version "0.3.3"
+  @version "0.4.0"
 
   def project do
     [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webauthn_components",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "main": "./priv/static/main.js",
   "repository": {},
   "files": [

--- a/priv/static/registration_hook.js
+++ b/priv/static/registration_hook.js
@@ -23,6 +23,7 @@ const RegistrationHook = {
       const challengeArray = base64ToArray(challenge);
 
       user.id = base64ToArray(user.id).buffer;
+      user.displayName = user.display_name;
 
       const publicKey = {
         attestation,

--- a/priv/static/registration_hook.js
+++ b/priv/static/registration_hook.js
@@ -23,7 +23,6 @@ const RegistrationHook = {
       const challengeArray = base64ToArray(challenge);
 
       user.id = base64ToArray(user.id).buffer;
-      user.displayName = user.display_name;
 
       const publicKey = {
         attestation,

--- a/test/webauthn_components/registration_component_test.exs
+++ b/test/webauthn_components/registration_component_test.exs
@@ -34,7 +34,6 @@ defmodule WebauthnComponents.RegistrationComponentTest do
     test "fails registration with invalid payload", %{element: element, view: view} do
       challenge = build(:registration_challenge)
       live_assign(view, :challenge, challenge)
-      live_assign(view, :user_handle, :crypto.strong_rand_bytes(64))
 
       attestation_64 = Base.encode64(:crypto.strong_rand_bytes(64), padding: false)
       raw_id_64 = Base.encode64(:crypto.strong_rand_bytes(64), padding: false)

--- a/test/webauthn_components/registration_component_test.exs
+++ b/test/webauthn_components/registration_component_test.exs
@@ -1,6 +1,7 @@
 defmodule WebauthnComponents.RegistrationComponentTest do
   use ComponentCase, async: true
   alias WebauthnComponents.RegistrationComponent
+  alias WebauthnComponents.WebauthnUser
 
   @id "registration-component"
 
@@ -19,7 +20,14 @@ defmodule WebauthnComponents.RegistrationComponentTest do
   end
 
   describe "handle_event/3 - register" do
-    test "sends registration challenge to client", %{element: element} do
+    test "sends registration challenge to client", %{element: element, view: view} do
+      webauthn_user = %WebauthnUser{
+        id: :crypto.strong_rand_bytes(64),
+        name: "testUser",
+        display_name: "Test User"
+      }
+
+      live_assign(view, :webauthn_user, webauthn_user)
       clicked_element = render_click(element)
       assert clicked_element =~ "<button"
       assert clicked_element =~ "phx-click=\"register\""


### PR DESCRIPTION
# Overview

Resolves #44 

This PR allows the parent LiveView to send user details (`id`, `name`, `displayName`) used by the WebAuthn API. The name is displayed to the user during registration and authentication, and the changes here will allow multiple users to share the same device.

The parent LiveView will be responsible for determining what appears as the name and display name. Some apps will choose email, others will choose usernames, for example.

## Changes

- Added `WebauthnComponents.WebauthnUser` struct
- Added logic for handling the new struct
- Removed all references to `:user_handle`
## Screenshots

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/13895134/236371780-fdb2c194-c180-44a4-86bb-d36cf9077962.png">


## Tests

```shell
mix test

22:00:46.533 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.344.0>}

22:00:46.533 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.343.0>}

22:00:46.533 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.354.0>}

22:00:46.533 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.349.0>}

22:00:46.535 [debug] Replied in 4ms

22:00:46.535 [debug] Replied in 4ms

22:00:46.535 [debug] Replied in 4ms

22:00:46.535 [debug] Replied in 4ms

22:00:46.536 [debug] HANDLE EVENT
  Component: WebauthnComponents.TokenComponent
  View: LiveIsolatedComponent.View
  Event: "error"
  Parameters: %{"message" => "test message", "name" => "test name", "stack" => %{}}

22:00:46.536 [debug] Replied in 33µs
.
22:00:46.536 [debug] HANDLE EVENT
  Component: WebauthnComponents.RegistrationComponent
  View: LiveIsolatedComponent.View
  Event: "invalid"
  Parameters: %{"invalid_key" => "invalid value"}

22:00:46.536 [debug] Replied in 17µs
.
22:00:46.537 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.370.0>}

22:00:46.537 [debug] Replied in 31µs

22:00:46.537 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.374.0>}

22:00:46.537 [debug] Replied in 91µs

22:00:46.537 [debug] HANDLE EVENT
  Component: WebauthnComponents.SupportComponent
  View: LiveIsolatedComponent.View
  Event: "passkeys-supported"
  Parameters: %{"supported" => true}

22:00:46.537 [debug] Replied in 44µs

22:00:46.538 [debug] HANDLE EVENT
  Component: WebauthnComponents.AuthenticationComponent
  View: LiveIsolatedComponent.View
  Event: "authenticate"
  Parameters: %{}
...
22:00:46.539 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.383.0>}

22:00:46.539 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.387.0>}

22:00:46.539 [debug] Replied in 51µs

22:00:46.539 [debug] Replied in 51µs

22:00:46.539 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.381.0>}

22:00:46.539 [debug] Replied in 36µs

22:00:46.539 [debug] HANDLE EVENT
  Component: WebauthnComponents.SupportComponent
  View: LiveIsolatedComponent.View
  Event: "invalid"
  Parameters: %{"invalid_key" => "invalid value"}

22:00:46.539 [debug] Replied in 20µs

22:00:46.539 [debug] HANDLE EVENT
  Component: WebauthnComponents.TokenComponent
  View: LiveIsolatedComponent.View
  Event: "invalid"
  Parameters: %{"invalid_key" => "invalid value"}

22:00:46.539 [debug] Replied in 24µs
...
22:00:46.540 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.397.0>}

22:00:46.540 [debug] Replied in 34µs

22:00:46.540 [debug] Replied in 1ms

22:00:46.540 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.399.0>}

22:00:46.540 [debug] Replied in 53µs
..
22:00:46.540 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.407.0>}

22:00:46.540 [debug] Replied in 42µs

22:00:46.540 [debug] HANDLE EVENT
  Component: WebauthnComponents.TokenComponent
  View: LiveIsolatedComponent.View
  Event: "token-exists"
  Parameters: %{"token" => "1234"}

22:00:46.540 [debug] Replied in 15µs
.
22:00:46.541 [debug] HANDLE EVENT
  Component: WebauthnComponents.RegistrationComponent
  View: LiveIsolatedComponent.View
  Event: "register"
  Parameters: %{}

22:00:46.541 [debug] Replied in 61µs

22:00:46.541 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.414.0>}

22:00:46.541 [debug] Replied in 60µs
.
22:00:46.541 [debug] HANDLE EVENT
  Component: WebauthnComponents.TokenComponent
  View: LiveIsolatedComponent.View
  Event: "token-cleared"
  Parameters: %{"token" => nil}

22:00:46.541 [debug] Replied in 38µs
.
22:00:46.541 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.419.0>}

22:00:46.541 [debug] Replied in 36µs

22:00:46.541 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.423.0>}

22:00:46.541 [debug] Replied in 27µs

22:00:46.542 [debug] HANDLE EVENT
  Component: WebauthnComponents.TokenComponent
  View: LiveIsolatedComponent.View
  Event: "token-stored"
  Parameters: %{"token" => "123456"}

22:00:46.542 [debug] Replied in 21µs

22:00:46.542 [debug] HANDLE EVENT
  Component: WebauthnComponents.RegistrationComponent
  View: LiveIsolatedComponent.View
  Event: "error"
  Parameters: %{"message" => "test message", "name" => "test name", "stack" => %{}}

22:00:46.542 [debug] Replied in 20µs
..
22:00:46.542 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.431.0>}

22:00:46.542 [debug] Replied in 39µs

22:00:46.543 [debug] HANDLE EVENT
  Component: WebauthnComponents.RegistrationComponent
  View: LiveIsolatedComponent.View
  Event: "registration-attestation"
  Parameters: %{"attestation64" => "cNEYi+IEPP+wsZzGH5Nw29fDo6TJwjkW3/8NCB/XZTKENSn5eZPAEaIWNDhU6H74vDWgfTIhgsxTk494hlLS9A", "clientData" => [], "rawId64" => "Gz2w0GkHBfKByC+F50hkdxVPC5QgohgnefEOKIBU4oMc3vpmGIBFR35h84nShF83GvXfeDdX4+NxrSXimuQjsA", "type" => "public-key"}

22:00:46.548 [debug] Replied in 5ms
.
Finished in 0.1 seconds (0.1s async, 0.00s sync)
16 tests, 0 failures

Randomized with seed 419416
```

## Collaborators

1. @type1fool
