### PR TITLE
Update origin

### DIFF
--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -128,7 +128,7 @@ defmodule WebauthnComponents.RegistrationComponent do
     challenge =
       Wax.new_registration_challenge(
         attestation: attestation,
-        origin: host_uri.host,
+        origin: URI.to_string(host_uri),
         rp_id: :auto,
         trusted_attestation_types: [:none, :basic]
       )

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -110,7 +110,7 @@ defmodule WebauthnComponents.RegistrationComponent do
   end
 
   def handle_event("register", _params, socket) do
-    %{assigns: assigns, host_uri: host_uri} = socket
+    %{assigns: assigns, endpoint: endpoint, host_uri: host_uri} = socket
 
     %{
       app: app_name,
@@ -125,10 +125,16 @@ defmodule WebauthnComponents.RegistrationComponent do
 
     attestation = "none"
 
+    origin =
+      case host_uri do
+        %URI{} -> URI.to_string(host_uri)
+        _ -> endpoint.url
+      end
+
     challenge =
       Wax.new_registration_challenge(
         attestation: attestation,
-        origin: URI.to_string(host_uri),
+        origin: origin,
         rp_id: :auto,
         trusted_attestation_types: [:none, :basic]
       )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule WebauthnComponents.MixProject do
   # Don't forget to change the version in `package.json`
   @name "WebauthnComponents"
   @source_url "https://github.com/liveshowy/webauthn_components"
-  @version "0.6.2"
+  @version "0.6.3"
 
   def project do
     [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webauthn_components",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "./priv/static/main.js",
   "repository": {},
   "files": [


### PR DESCRIPTION
# Overview

This PR uses the socket's stringified URI as the origin so that the domain where the user registers will be the relying party.

## Changes

- Converted URI to string
- updated pkg version

## Tests

I used this branch in an app that was deployed and successfully registered a key at a domain that was not the endpoint URL.

## Collaborators

1. @type1fool
