### PR TITLE
54 - Fix RP Configuration

### DIFF
--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -18,6 +18,8 @@ defmodule WebauthnComponents.RegistrationComponent do
   - `@disabled` (Optional) Set to `true` when the `SupportHook` indicates WebAuthn is not supported or enabled by the browser. Defaults to `false`.
   - `@id` (Optional) An HTML element ID.
   - `@require_resident_key` (Optional) Set to `false` to allow non-passkey credentials. Defaults to `true`.
+  - `@relying_party` (Optional) URL to override the default RP value based on the origin. For example, the default may be `www.example.com`, and passing `example.com` would allow the credential to be used across subdomains, ie `mail.example.com`, `forum.example.com`, and so on.
+    - If set, the same value must be passed to the `AuthenticationComponent`.
 
   ## Events
 
@@ -62,6 +64,7 @@ defmodule WebauthnComponents.RegistrationComponent do
       |> assign_new(:require_resident_key, fn -> true end)
       |> assign_new(:display_text, fn -> "Sign Up" end)
       |> assign_new(:show_icon?, fn -> true end)
+      |> assign_new(:relying_party, fn -> nil end)
     }
   end
 
@@ -116,7 +119,8 @@ defmodule WebauthnComponents.RegistrationComponent do
       app: app_name,
       id: id,
       require_resident_key: require_resident_key,
-      webauthn_user: webauthn_user
+      webauthn_user: webauthn_user,
+      relying_party: relying_party
     } = assigns
 
     if not is_struct(webauthn_user, WebauthnUser) do
@@ -131,11 +135,13 @@ defmodule WebauthnComponents.RegistrationComponent do
         _ -> endpoint.url
       end
 
+    rp_id = relying_party || :auto
+
     challenge =
       Wax.new_registration_challenge(
         attestation: attestation,
         origin: origin,
-        rp_id: :auto,
+        rp_id: rp_id,
         trusted_attestation_types: [:none, :basic]
       )
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule WebauthnComponents.MixProject do
   # Don't forget to change the version in `package.json`
   @name "WebauthnComponents"
   @source_url "https://github.com/liveshowy/webauthn_components"
-  @version "0.6.3"
+  @version "0.6.4"
 
   def project do
     [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webauthn_components",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "main": "./priv/static/main.js",
   "repository": {},
   "files": [


### PR DESCRIPTION
# Overview

Resolves #54

What problem is being solved by this branch?

## Changes

- Updated `AuthenticationComponent` to use the socket's `host_uri` as its origin by default.
- Added optional `@relying_party` assign to `RegistrationComponent` and `AuthenticationComponent`

## Tests

```elixir
mix test
Compiling 3 files (.ex)
Generated webauthn_components app

14:24:13.106 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.304.0>}

14:24:13.106 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.299.0>}

14:24:13.106 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.297.0>}

14:24:13.108 [debug] Replied in 6ms

14:24:13.108 [debug] Replied in 6ms

14:24:13.108 [debug] Replied in 6ms

14:24:13.109 [debug] HANDLE EVENT "passkeys-supported" in LiveIsolatedComponent.View
  Component: WebauthnComponents.SupportComponent
  Parameters: %{"supported" => true}

14:24:13.109 [debug] Replied in 43µs

14:24:13.109 [debug] HANDLE EVENT "authenticate" in LiveIsolatedComponent.View
  Component: WebauthnComponents.AuthenticationComponent
  Parameters: %{}

14:24:13.109 [debug] HANDLE EVENT "register" in LiveIsolatedComponent.View
  Component: WebauthnComponents.RegistrationComponent
  Parameters: %{}

14:24:13.113 [debug] Replied in 3ms
.
14:24:13.113 [debug] Replied in 3ms
..
14:24:13.114 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.318.0>}

14:24:13.114 [debug] Replied in 105µs

14:24:13.114 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.324.0>}

14:24:13.114 [debug] HANDLE EVENT "invalid" in LiveIsolatedComponent.View
  Component: WebauthnComponents.SupportComponent
  Parameters: %{"invalid_key" => "invalid value"}

14:24:13.114 [debug] Replied in 35µs
.
14:24:13.114 [debug] Replied in 48µs
.
14:24:13.114 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.322.0>}

14:24:13.114 [debug] Replied in 77µs

14:24:13.115 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.334.0>}

14:24:13.115 [debug] Replied in 66µs

14:24:13.115 [debug] HANDLE EVENT "registration-attestation" in LiveIsolatedComponent.View
  Component: WebauthnComponents.RegistrationComponent
  Parameters: %{"attestation64" => "ghhwu5EkDadcEuXqG3XFUD63Hr1GdEVqh3c6Va09nsrK4kq2geaSu0OCHL9+mTleK0Iqud729GlbKa6gvwA1+Q", "clientData" => [], "rawId64" => "TpGWcr170qRjfn1vRe+RmwjNamwBxnXip+KW6bLLcA4D9EWU841EZuM9RKTVDM42ZYevApi8cc2usFW5wuZE2w", "type" => "public-key"}
.
14:24:13.121 [debug] Replied in 6ms
.
14:24:13.122 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.341.0>}

14:24:13.122 [debug] Replied in 60µs

14:24:13.122 [debug] HANDLE EVENT "error" in LiveIsolatedComponent.View
  Component: WebauthnComponents.RegistrationComponent
  Parameters: %{"message" => "test message", "name" => "test name", "stack" => %{}}

14:24:13.122 [debug] Replied in 31µs
.
14:24:13.123 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.347.0>}

14:24:13.123 [debug] Replied in 64µs

14:24:13.123 [debug] HANDLE EVENT "invalid" in LiveIsolatedComponent.View
  Component: WebauthnComponents.RegistrationComponent
  Parameters: %{"invalid_key" => "invalid value"}

14:24:13.123 [debug] Replied in 32µs
.
14:24:13.124 [debug] MOUNT LiveIsolatedComponent.View
  Parameters: :not_mounted_at_router
  Session: %{"live_isolated_component_store_agent" => #PID<0.353.0>}

14:24:13.124 [debug] Replied in 37µs
.
Finished in 0.1 seconds (0.1s async, 0.00s sync)
10 tests, 0 failures

Randomized with seed 956693
```

## Collaborators

1. @type1fool
