### PR TITLE
add alias to RequireUser hook to fix dialyzer "Unknown type" warning

### DIFF
--- a/templates/session_hooks/require_user.ex
+++ b/templates/session_hooks/require_user.ex
@@ -28,6 +28,7 @@ defmodule <%= inspect @web_pascal_case %>.SessionHooks.RequireUser do
   ```
   """
   alias <%= inspect @app_pascal_case %>.Identity.User
+  alias Phoenix.LiveView.Socket
   import Phoenix.LiveView
   use <%= inspect @web_pascal_case %>, :verified_routes
 


### PR DESCRIPTION
# Overview

Fixes the following dialyzer warning:

```
lib/my_app_web/session_hooks/require_user.ex:34:unknown_type
Unknown type: Socket.t/0.
```

## Changes

- Added an `alias` pointing to `Phoenix.LiveView.Socket` in `require_user.ex`, so dialyzer knows what `Socket.t()` is supposed to be.

