### PR TITLE
Add passkey autofill

### DIFF
--- a/lib/webauthn_components/authentication_component.ex
+++ b/lib/webauthn_components/authentication_component.ex
@@ -126,9 +126,16 @@ defmodule WebauthnComponents.AuthenticationComponent do
     {:ok, assign(socket, assigns)}
   end
 
-  def handle_event("authenticate", _params, socket) do
+  def handle_event("authenticate", params, socket) do
     %{assigns: assigns, endpoint: endpoint} = socket
     %{id: id} = assigns
+
+    supports_passkey_autofill = Map.has_key?(params, "supports_passkey_autofill")
+
+    event =
+      if supports_passkey_autofill,
+        do: "authentication-challenge-with-conditional-ui",
+        else: "authentication-challenge"
 
     challenge =
       Wax.new_authentication_challenge(
@@ -149,7 +156,7 @@ defmodule WebauthnComponents.AuthenticationComponent do
       :noreply,
       socket
       |> assign(:challenge, challenge)
-      |> push_event("authentication-challenge", challenge_data)
+      |> push_event(event, challenge_data)
     }
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule WebauthnComponents.MixProject do
   # Don't forget to change the version in `package.json`
   @name "WebauthnComponents"
   @source_url "https://github.com/liveshowy/webauthn_components"
-  @version "0.6.6"
+  @version "0.7.0"
 
   def project do
     [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webauthn_components",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "main": "./priv/static/main.js",
   "repository": {},
   "files": [

--- a/priv/static/abort_controller.js
+++ b/priv/static/abort_controller.js
@@ -7,9 +7,9 @@ class BaseAbortControllerService {
     // Abort any existing calls to navigator.credentials.create() or navigator.credentials.get()
     if (this.controller) {
       const abortError = new Error(
-        'Cancelling existing WebAuthn API call for new one',
+        "Cancelling existing WebAuthn API call for new one"
       );
-      abortError.name = 'AbortError';
+      abortError.name = "AbortError";
       this.controller.abort(abortError);
     }
 
@@ -17,6 +17,21 @@ class BaseAbortControllerService {
 
     this.controller = newController;
     return newController.signal;
+  }
+
+  /**
+   * Manually cancel any active WebAuthn registration or authentication attempt.
+   */
+  cancelCeremony() {
+    if (this.controller) {
+      const abortError = new Error(
+        "Manually cancelling existing WebAuthn API call"
+      );
+      abortError.name = "AbortError";
+      this.controller.abort(abortError);
+
+      this.controller = undefined;
+    }
   }
 }
 

--- a/priv/static/abort_controller.js
+++ b/priv/static/abort_controller.js
@@ -1,0 +1,27 @@
+class BaseAbortControllerService {
+  /**
+   * Prepare an abort signal that will help support multiple auth attempts without needing to
+   * reload the page.
+   */
+  createNewAbortSignal() {
+    // Abort any existing calls to navigator.credentials.create() or navigator.credentials.get()
+    if (this.controller) {
+      const abortError = new Error(
+        'Cancelling existing WebAuthn API call for new one',
+      );
+      abortError.name = 'AbortError';
+      this.controller.abort(abortError);
+    }
+
+    const newController = new AbortController();
+
+    this.controller = newController;
+    return newController.signal;
+  }
+}
+
+/**
+ * A service singleton to help ensure that only a single navigator.crendetials ceremony is active at a time.
+ *
+ */
+export const AbortControllerService = new BaseAbortControllerService();

--- a/priv/static/authentication_hook.js
+++ b/priv/static/authentication_hook.js
@@ -1,15 +1,43 @@
 import { base64ToArray, arrayBufferToBase64, handleError } from "./utils";
+import { browserSupportsPasskeyAutofill } from "./browser_supports_passkey_autofill"
+import { AbortControllerService } from "./abort_controller"
 
 export const AuthenticationHook = {
   mounted() {
     console.info(`AuthenticationHook mounted`);
 
+    this.checkConditionalUIAvailable(this)
+
     this.handleEvent("authentication-challenge", (event) =>
-      this.handlePasskeyAuthentication(event, this)
+      this.handlePasskeyAuthentication(event, this, 'optional')
+    );
+  
+    this.handleEvent("authentication-challenge-with-conditional-ui", (event) =>
+      this.handlePasskeyAuthentication(event, this, 'conditional')
     );
   },
 
-  async handlePasskeyAuthentication(event, context) {
+  async checkConditionalUIAvailable(context) {
+    if (!(await browserSupportsPasskeyAutofill())) {
+      throw Error('Browser does not support WebAuthn autofill');
+    }
+
+    // Check for an <input> with "webauthn" in its `autocomplete` attribute
+    const eligibleInputs = document.querySelectorAll(
+      'input[autocomplete$=\'webauthn\']',
+    );
+
+    // WebAuthn autofill requires at least one valid input
+    if (eligibleInputs.length < 1) {
+      throw Error(
+        'No <input> with "webauthn" as the only or last value in its `autocomplete` attribute was detected',
+      );
+    }
+
+    context.pushEventTo(context.el, "authenticate", {"supports_passkey_autofill": true})
+  },
+
+  async handlePasskeyAuthentication(event, context, mediation) {
     try {
       const { challenge, timeout, rpId, allowCredentials, userVerification } =
         event;
@@ -25,6 +53,8 @@ export const AuthenticationHook = {
       };
       const credential = await navigator.credentials.get({
         publicKey,
+        signal: AbortControllerService.createNewAbortSignal(),
+        mediation: mediation
       });
       const { rawId, response, type } = credential;
       const { clientDataJSON, authenticatorData, signature, userHandle } =
@@ -34,6 +64,15 @@ export const AuthenticationHook = {
       const authenticatorData64 = arrayBufferToBase64(authenticatorData);
       const signature64 = arrayBufferToBase64(signature);
       const userHandle64 = arrayBufferToBase64(userHandle);
+
+      console.log(JSON.stringify({
+        rawId64,
+        type,
+        clientDataArray,
+        authenticatorData64,
+        signature64,
+        userHandle64,
+      }))
 
       context.pushEventTo(context.el, "authentication-attestation", {
         rawId64,

--- a/priv/static/authentication_hook.js
+++ b/priv/static/authentication_hook.js
@@ -65,15 +65,6 @@ export const AuthenticationHook = {
       const signature64 = arrayBufferToBase64(signature);
       const userHandle64 = arrayBufferToBase64(userHandle);
 
-      console.log(JSON.stringify({
-        rawId64,
-        type,
-        clientDataArray,
-        authenticatorData64,
-        signature64,
-        userHandle64,
-      }))
-
       context.pushEventTo(context.el, "authentication-attestation", {
         rawId64,
         type,

--- a/priv/static/browser_supports_passkey_autofill.js
+++ b/priv/static/browser_supports_passkey_autofill.js
@@ -2,7 +2,7 @@ export function browserSupportsPasskeyAutofill() {
   const globalPublicKeyCredential = window.PublicKeyCredential;
 
   if (globalPublicKeyCredential.isConditionalMediationAvailable === undefined) {
-    return new Promise((resolve) => resolve(false));
+    return Promise.resolve(false);
   }
 
   return globalPublicKeyCredential.isConditionalMediationAvailable();

--- a/priv/static/browser_supports_passkey_autofill.js
+++ b/priv/static/browser_supports_passkey_autofill.js
@@ -1,0 +1,9 @@
+export function browserSupportsPasskeyAutofill() {
+  const globalPublicKeyCredential = window.PublicKeyCredential;
+
+  if (globalPublicKeyCredential.isConditionalMediationAvailable === undefined) {
+    return new Promise((resolve) => resolve(false));
+  }
+
+  return globalPublicKeyCredential.isConditionalMediationAvailable();
+}

--- a/priv/static/registration_hook.js
+++ b/priv/static/registration_hook.js
@@ -1,4 +1,5 @@
 import { base64ToArray, arrayBufferToBase64, handleError } from "./utils";
+import { AbortControllerService } from "./abort_controller"
 
 export const RegistrationHook = {
   mounted() {
@@ -43,6 +44,7 @@ export const RegistrationHook = {
 
       const credential = await navigator.credentials.create({
         publicKey,
+        signal: AbortControllerService.createNewAbortSignal(),
       });
 
       const { rawId, response, type } = credential;

--- a/priv/static/registration_hook.js
+++ b/priv/static/registration_hook.js
@@ -1,5 +1,5 @@
 import { base64ToArray, arrayBufferToBase64, handleError } from "./utils";
-import { AbortControllerService } from "./abort_controller"
+import { AbortControllerService } from "./abort_controller";
 
 export const RegistrationHook = {
   mounted() {
@@ -60,6 +60,9 @@ export const RegistrationHook = {
         type,
       });
     } catch (error) {
+      if (error.toString().includes("NotAllowedError:")) {
+        AbortControllerService.cancelCeremony();
+      }
       console.error(error);
       handleError(error, context);
     }

--- a/templates/live_views/authentication_live.html.heex
+++ b/templates/live_views/authentication_live.html.heex
@@ -16,7 +16,7 @@
     >
       <p>Create a <strong>new</strong> account:</p>
 
-      <.input type="email" field={form[:email]} label="Email" phx-debounce="250" />
+      <.input type="email" field={form[:email]} label="Email" phx-debounce="250" autocomplete="username webauthn" />
       <.live_component
         disabled={@form.source.valid? == false}
         module={RegistrationComponent}


### PR DESCRIPTION
# Overview

Added Passkey autofill on browsers its supports
Resolves [#57](https://github.com/liveshowy/webauthn_components/issues/57)

## Changes

- Added `checkConditionalUIAvailable` on `authentication_hook` to enable passkey autofill
- Add AbortController Class to abort `navigation.crendentials.get`
- Add `browserSupportsPasskeyAutofill` helper

## Tests

I used my personal project with this changes and successfully autofill passkey on Safari/iOS and Chrome/Mac, also inputing email on input works just fine, like before.
[My personal project](https://insignia-notify.com/login)

## Collaborators

1. @danielgpinheiro

