### PR TITLE
Refactor to fix order of migration generation

### DIFF
--- a/lib/wac_gen/migrations.ex
+++ b/lib/wac_gen/migrations.ex
@@ -11,8 +11,14 @@ defmodule Wac.Gen.Migrations do
 
   @templates Map.keys(@template_files)
 
+  @template_order ~w(
+    users
+    user_keys
+    user_tokens
+    )
+
   def copy_templates(assigns) do
-    for template <- @templates do
+    for template <- @template_order do
       copy_template(template, assigns)
       # Pause to ensure unique timestamped files
       Process.sleep(1_000)


### PR DESCRIPTION
# Overview

Resolves #i60

Generate migrations in specific order.

## Changes

- Defined order of migrations
- Iterate on an ordered `list`, rather than a `map`.

## Tests

Could not work out a way to test this in-repo, but can generate an example app using the new/old `wac.install` to demonstrate.

## Collaborators

1. @type1fool
1. **more_collabs**
