### PR TITLE
use keyword list for migration template files

### DIFF
--- a/lib/wac_gen/migrations.ex
+++ b/lib/wac_gen/migrations.ex
@@ -3,13 +3,13 @@ defmodule Wac.Gen.Migrations do
 
   @template_path "../../templates/migrations"
 
-  @template_files %{
+  @template_files [
     users: "users.exs",
     user_keys: "user_keys.exs",
     user_tokens: "user_tokens.exs"
-  }
+  ]
 
-  @templates Map.keys(@template_files)
+  @templates Keyword.keys(@template_files)
 
   def copy_templates(assigns) do
     for template <- @templates do


### PR DESCRIPTION
# Overview

Resolves #60

Generate migrations in specific order.

## Changes

- Define order of migrations
- Iterate on an ordered `list`, rather than a `map`.

## Tests

Could not work out a way to test this in-repo, but can generate an example app using the new/old `wac.install` to demonstrate.

## Collaborators

1. @type1fool
1. @suranyami
