### PR TITLE
Check for pushed "registration-challenge" event in RegistrationComponentTest

### DIFF
--- a/test/webauthn_components/authentication_component_test.exs
+++ b/test/webauthn_components/authentication_component_test.exs
@@ -19,10 +19,14 @@ defmodule WebauthnComponents.AuthenticationComponentTest do
   end
 
   describe "handle_event/3 - authenticate" do
-    test "sends authentication challenge to client", %{element: element} do
+    test "sends authentication challenge to client", %{element: element, view: view} do
       clicked_element = render_click(element)
       assert clicked_element =~ "<button"
       assert clicked_element =~ "phx-click=\"authenticate\""
+
+      assert_push_event(view, "authentication-challenge", %{
+        id: "authentication-component"
+      })
     end
   end
 

--- a/test/webauthn_components/registration_component_test.exs
+++ b/test/webauthn_components/registration_component_test.exs
@@ -33,9 +33,10 @@ defmodule WebauthnComponents.RegistrationComponentTest do
       assert clicked_element =~ "<button"
       assert clicked_element =~ "phx-click=\"register\""
 
-      # TODO 1/10/2023
-      # Assert event was pushed to client
-      # Not supported by Phoenix.LiveViewTest or LiveIsolatedComponent
+      assert_push_event(view, "registration-challenge", %{
+        id: "registration-component",
+        user: ^webauthn_user
+      })
     end
   end
 


### PR DESCRIPTION
I'm not entirely sure that this is what you had in mind, but while seeing this `TODO` I remembered that [`LiveViewTest.assert_push_event/4`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveViewTest.html#assert_push_event/4) exists.