### PR TITLE
Enable RegistrationLiveTest

### DIFF
--- a/lib/wac_gen/tests.ex
+++ b/lib/wac_gen/tests.ex
@@ -5,7 +5,8 @@ defmodule Wac.Gen.Tests do
 
   @template_files %{
     identity: "identity_test.exs",
-    authentication_live: "authentication_live_test.exs"
+    authentication_live: "authentication_live_test.exs",
+    registration_live: "registration_live_test.exs"
   }
 
   @templates Map.keys(@template_files)
@@ -24,7 +25,8 @@ defmodule Wac.Gen.Tests do
     Code.format_file!(target)
   end
 
-  def copy_template(:authentication_live = template, assigns) when is_list(assigns) do
+  def copy_template(template, assigns)
+      when template in [:authentication_live, :registration_live] do
     web_snake_case = Keyword.fetch!(assigns, :web_snake_case)
     file_name = @template_files[template]
     template_dir = Path.expand(@template_path, __DIR__)


### PR DESCRIPTION
# Overview

The template `RegistrationLiveTest` has been written, but it is not included in the tests generator.

## Changes

- Enabled `registration_live_test.exs` template in `Wac.Gen.Tests`

## Tests

```elixir
➜  webauthn_components git:(enable-registration-tests) ✗ mix test
Running ExUnit with seed: 958854, max_cases: 20

............
Finished in 0.08 seconds (0.08s async, 0.00s sync)
12 tests, 0 failures
```

## Collaborators

1. @type1fool
