### PR TITLE
Implement `JSON.Encoder` for `WebauthnUser` and `UserKey`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.0.1
-elixir 1.17.2-otp-27
+erlang 27.2.2
+elixir 1.18.3-otp-27

--- a/lib/webauthn_components/webauthn_user.ex
+++ b/lib/webauthn_components/webauthn_user.ex
@@ -23,12 +23,11 @@ defmodule WebauthnComponents.WebauthnUser do
 
   defimpl JSON.Encoder, for: __MODULE__ do
     def encode(struct, encoder) do
-      map =
-        struct
-        |> Map.from_struct()
-        |> Map.put(:displayName, struct.display_name)
-        |> Map.delete(:display_name)
-        |> JSON.encode!(encoder)
+      struct
+      |> Map.from_struct()
+      |> Map.put(:displayName, struct.display_name)
+      |> Map.delete(:display_name)
+      |> JSON.encode!(encoder)
     end
   end
 end

--- a/lib/webauthn_components/webauthn_user.ex
+++ b/lib/webauthn_components/webauthn_user.ex
@@ -13,13 +13,22 @@ defmodule WebauthnComponents.WebauthnUser do
 
   defimpl Jason.Encoder, for: __MODULE__ do
     def encode(struct, opts) do
+      struct
+      |> Map.from_struct()
+      |> Map.put(:displayName, struct.display_name)
+      |> Map.delete(:display_name)
+      |> Jason.Encode.map(opts)
+    end
+  end
+
+  defimpl JSON.Encoder, for: __MODULE__ do
+    def encode(struct, encoder) do
       map =
         struct
         |> Map.from_struct()
         |> Map.put(:displayName, struct.display_name)
         |> Map.delete(:display_name)
-
-      Jason.Encode.map(map, opts)
+        |> JSON.encode!(encoder)
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule WebauthnComponents.MixProject do
       deps: deps(),
       description: description(),
       docs: docs(),
-      elixir: "~> 1.13",
+      elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: @name,
       package: package(),

--- a/templates/schemas/user_key.ex
+++ b/templates/schemas/user_key.ex
@@ -26,6 +26,7 @@ defmodule <%= inspect @app_pascal_case %>.Identity.UserKey do
   @primary_key {:id, Ecto.ULID, autogenerate: true}
   @foreign_key_type Ecto.ULID
   @derive {Jason.Encoder, only: [:key_id, :public_key, :label, :last_used_at]}
+  @derive {JSON.Encoder, only: [:key_id, :public_key, :label, :last_used_at]}
   schema "user_keys" do
     field :label, :string, default: "default"
     field :key_id, :binary


### PR DESCRIPTION
# Overview

Resolves #91

Elixir's new JSON module provides native support for encoding and decoding JSON data, and it is available as of Elixir 1.18.

- https://hexdocs.pm/elixir/JSON.Encoder.html

## Changes

- Add encoder for new JSON module
- Increase Elixir required version to 1.18

## Tests

```elixir
➜  webauthn_components git:(json-encoder) ✗ mix test
Running ExUnit with seed: 398682, max_cases: 20

............
Finished in 0.08 seconds (0.08s async, 0.00s sync)
12 tests, 0 failures
```

## Collaborators

1. @type1fool
