### PR TITLE
Support cross-platform

### DIFF
--- a/lib/wac_gen/app_html.ex
+++ b/lib/wac_gen/app_html.ex
@@ -1,8 +1,6 @@
 defmodule Wac.Gen.AppHtml do
   @moduledoc false
 
-  @header_regex ~r/\<header.*\<\/header\>/mis
-
   def update_app_html(assigns) do
     web_snake_case = Keyword.fetch!(assigns, :web_snake_case)
     file_path = Path.join(["lib", web_snake_case, "components", "layouts", "app.html.heex"])
@@ -10,10 +8,12 @@ defmodule Wac.Gen.AppHtml do
     modified_file_contents =
       file_path
       |> File.read!()
-      |> String.replace(@header_regex, navbar_component(assigns))
+      |> String.replace(header_regex(), navbar_component(assigns))
 
     File.write!(file_path, modified_file_contents)
   end
+
+  defp header_regex, do: ~r/\<header.*\<\/header\>/mis
 
   defp navbar_component(assigns) do
     web_pascal_case = Keyword.fetch!(assigns, :web_pascal_case)

--- a/lib/wac_gen/javascript.ex
+++ b/lib/wac_gen/javascript.ex
@@ -1,9 +1,6 @@
 defmodule Wac.Gen.Javascript do
   @moduledoc false
 
-  @import_regex Regex.compile!("(import {\s?LiveSocket\s?} from \"phoenix_live_view\";?)")
-  @socket_regex Regex.compile!("(params: {\s?_csrf_token: csrfToken\s?})")
-
   @import_hooks """
   import {
     SupportHook,
@@ -22,9 +19,14 @@ defmodule Wac.Gen.Javascript do
     updated_contents =
       javascript_path
       |> File.read!()
-      |> String.replace(@import_regex, "\\1\n#{@import_hooks}")
-      |> String.replace(@socket_regex, "\\1,\n#{@socket_hooks}")
+      |> String.replace(import_regex(), "\\1\n#{@import_hooks}")
+      |> String.replace(socket_regex(), "\\1,\n#{@socket_hooks}")
 
     File.write!(javascript_path, updated_contents)
   end
+
+  defp import_regex,
+    do: Regex.compile!("(import {\s?LiveSocket\s?} from \"phoenix_live_view\";?)")
+
+  defp socket_regex, do: Regex.compile!("(params: {\s?_csrf_token: csrfToken\s?})")
 end

--- a/lib/wac_gen/javascript.ex
+++ b/lib/wac_gen/javascript.ex
@@ -25,8 +25,9 @@ defmodule Wac.Gen.Javascript do
     File.write!(javascript_path, updated_contents)
   end
 
-  defp import_regex,
-    do: Regex.compile!("(import {\s?LiveSocket\s?} from \"phoenix_live_view\";?)")
+  defp import_regex do
+    Regex.compile!("(import {\s?LiveSocket\s?} from \"phoenix_live_view\";?)")
+  end
 
   defp socket_regex, do: Regex.compile!("(params: {\s?_csrf_token: csrfToken\s?})")
 end

--- a/lib/webauthn_components/authentication_component.ex
+++ b/lib/webauthn_components/authentication_component.ex
@@ -56,7 +56,7 @@ defmodule WebauthnComponents.AuthenticationComponent do
     {
       :ok,
       socket
-      |> assign(:challenge, fn -> nil end)
+      |> assign_new(:challenge, fn -> nil end)
       |> assign_new(:id, fn -> "authentication-component" end)
       |> assign_new(:class, fn -> "" end)
       |> assign_new(:disabled, fn -> nil end)

--- a/lib/webauthn_components/icon_components.ex
+++ b/lib/webauthn_components/icon_components.ex
@@ -20,7 +20,7 @@ defmodule WebauthnComponents.IconComponents do
       viewBox="0 0 24 24"
       stroke-width="1.5"
       stroke="currentColor"
-      class="w-full h-full"
+      class="w-full h-full min-w-4 min-h-4"
     >
       <path
         stroke-linecap="round"
@@ -39,7 +39,7 @@ defmodule WebauthnComponents.IconComponents do
       fill="currentColor"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      class="w-full h-full"
+      class="w-full h-full min-w-4 min-h-4"
     >
       <path d="M 23.5,12 L 21,10 L 21,11 L 8,11 L 10.5,6.5 C 10.75,6 11.125,5.5 11.5,5.5 C 12.75,5.5 13.25,5.5 13.5,5.5 C 13.75,7 14.5,8 15.5,8 C 16.75,8 17.5,7 17.5,5.5 C 17.5,4 16.75,3 15.5,3 C 14.5,3 13.75,4 13.5,5.5 L 11.5,5.5 C 11,5.5 10.25,6.25 10,6.75 L 7,11 L 5,11 C 4.75,9 3.5,7.5 2,7.5 C 0.75,7.5 0,9.25 0,12 C 0,14.75 0.75,16.5 2,16.5 C 3.5,16.5 4.75,15 5,13 L 7,13 L 10,17.25 C 10.25,17.75 11,18.5 11.5,18.5 L 13.5,18.5 L 13.5,20 L 16,20 L 16,16 L 13.5,16 L 13.5,17.5 L 11.5,17.5 C 11.125,17.5 10.75,17 10.5,16.5 L 8,13 L 21,13 L 21,14 L 23.5,12 z" />
     </svg>

--- a/lib/webauthn_components/icon_components.ex
+++ b/lib/webauthn_components/icon_components.ex
@@ -2,6 +2,15 @@ defmodule WebauthnComponents.IconComponents do
   @moduledoc false
   use Phoenix.Component
 
+  attr :type, :atom, required: true, values: [:key, :usb]
+
+  def icon(assigns) do
+    ~H"""
+    <.icon_key :if={@type == :key} />
+    <.icon_usb :if={@type == :usb} />
+    """
+  end
+
   @doc false
   def icon_key(assigns) do
     ~H"""
@@ -18,6 +27,21 @@ defmodule WebauthnComponents.IconComponents do
         stroke-linejoin="round"
         d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z"
       />
+    </svg>
+    """
+  end
+
+  @doc false
+  def icon_usb(assigns) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      class="w-full h-full"
+    >
+      <path d="M 23.5,12 L 21,10 L 21,11 L 8,11 L 10.5,6.5 C 10.75,6 11.125,5.5 11.5,5.5 C 12.75,5.5 13.25,5.5 13.5,5.5 C 13.75,7 14.5,8 15.5,8 C 16.75,8 17.5,7 17.5,5.5 C 17.5,4 16.75,3 15.5,3 C 14.5,3 13.75,4 13.5,5.5 L 11.5,5.5 C 11,5.5 10.25,6.25 10,6.75 L 7,11 L 5,11 C 4.75,9 3.5,7.5 2,7.5 C 0.75,7.5 0,9.25 0,12 C 0,14.75 0.75,16.5 2,16.5 C 3.5,16.5 4.75,15 5,13 L 7,13 L 10,17.25 C 10.25,17.75 11,18.5 11.5,18.5 L 13.5,18.5 L 13.5,20 L 16,20 L 16,16 L 13.5,16 L 13.5,17.5 L 11.5,17.5 C 11.125,17.5 10.75,17 10.5,16.5 L 8,13 L 21,13 L 21,14 L 23.5,12 z" />
     </svg>
     """
   end

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -113,29 +113,44 @@ defmodule WebauthnComponents.RegistrationComponent do
     end
 
     ~H"""
-    <span>
-      <.button
-        :for={
-          %{authenticator_attachment: authenticator_attachment, display_text: display_text} <- [
-            %{authenticator_attachment: "platform", display_text: @platform_display_text},
-            %{authenticator_attachment: "cross-platform", display_text: @cross_platform_display_text}
-          ]
-        }
-        id={"#{@id}-#{authenticator_attachment}"}
-        phx-hook="RegistrationHook"
-        phx-target={@myself}
-        phx-click="register"
-        phx-value-authenticator-attachment={authenticator_attachment}
-        data-check_uvpa_available={if @check_uvpa_available, do: "true"}
-        data-uvpa_error_message={@uvpa_error_message}
-        class={@class}
-        title="Create a new account"
-        disabled={@disabled}
-      >
-        <span :if={@show_icon?} class="w-4 aspect-square opacity-70"><.icon_key /></span>
-        <span><%= display_text %></span>
-      </.button>
-    </span>
+    <div class="flex flex-col space-y-4">
+      <span :for={
+        %{
+          authenticator_attachment: authenticator_attachment,
+          display_text: display_text,
+          icon_type: icon_type
+        } <- [
+          %{
+            authenticator_attachment: "platform",
+            display_text: @platform_display_text,
+            icon_type: :key
+          },
+          %{
+            authenticator_attachment: "cross-platform",
+            display_text: @cross_platform_display_text,
+            icon_type: :usb
+          }
+        ]
+      }>
+        <.button
+          id={"#{@id}-#{authenticator_attachment}"}
+          phx-hook="RegistrationHook"
+          phx-target={@myself}
+          phx-click="register"
+          phx-value-authenticator-attachment={authenticator_attachment}
+          data-check_uvpa_available={if @check_uvpa_available, do: "true"}
+          data-uvpa_error_message={@uvpa_error_message}
+          class={@class}
+          title="Create a new account"
+          disabled={@disabled}
+        >
+          <span :if={@show_icon?} class="w-4 aspect-square opacity-70">
+            <.icon type={icon_type} />
+          </span>
+          <span><%= display_text %></span>
+        </.button>
+      </span>
+    </div>
     """
   end
 

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -12,7 +12,8 @@ defmodule WebauthnComponents.RegistrationComponent do
 
   - `@user`: (**Required**) A `WebauthnComponents.WebauthnUser` struct.
   - `@challenge`: (Internal) A `Wax.Challenge` struct created by the component, used to create a new credential request in the client.
-  - `@display_text` (Optional) The text displayed inside the button. Defaults to "Sign Up".
+  - `@platform_display_text` (Optional) The text displayed inside the "platform" button. Defaults to "Sign Up".
+  - `@cross_platform_display_text` (Optional) The text displayed inside the "cross-platform" button. Defaults to "Sign Up With Connected Device".
   - `@show_icon?` (Optional) Controls visibility of the key icon. Defaults to `true`.
   - `@class` (Optional) CSS classes for overriding the default button style.
   - `@disabled` (Optional) Set to `true` when the `SupportHook` indicates WebAuthn is not supported or enabled by the browser. Defaults to `false`.
@@ -78,7 +79,8 @@ defmodule WebauthnComponents.RegistrationComponent do
       |> assign_new(:uvpa_error_message, fn ->
         "Registration unavailable. Your device does not support passkeys. Please install a passkey authenticator."
       end)
-      |> assign_new(:display_text, fn -> "Sign Up" end)
+      |> assign_new(:platform_display_text, fn -> "Sign Up" end)
+      |> assign_new(:cross_platform_display_text, fn -> "Sign Up With Connected Device" end)
       |> assign_new(:show_icon?, fn -> true end)
       |> assign_new(:relying_party, fn -> nil end)
     }
@@ -114,9 +116,9 @@ defmodule WebauthnComponents.RegistrationComponent do
     <span>
       <.button
         :for={
-          %{authenticator_attachment: authenticator_attachment} <- [
-            %{authenticator_attachment: "platform"},
-            %{authenticator_attachment: "cross-platform"}
+          %{authenticator_attachment: authenticator_attachment, display_text: display_text} <- [
+            %{authenticator_attachment: "platform", display_text: @platform_display_text},
+            %{authenticator_attachment: "cross-platform", display_text: @cross_platform_display_text}
           ]
         }
         id={"#{@id}-#{authenticator_attachment}"}
@@ -131,7 +133,7 @@ defmodule WebauthnComponents.RegistrationComponent do
         disabled={@disabled}
       >
         <span :if={@show_icon?} class="w-4 aspect-square opacity-70"><.icon_key /></span>
-        <span><%= @display_text %></span>
+        <span><%= display_text %></span>
       </.button>
     </span>
     """

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -142,6 +142,7 @@ defmodule WebauthnComponents.RegistrationComponent do
           phx-value-authenticator-attachment={authenticator_attachment}
           data-check_uvpa_available={if @check_uvpa_available, do: "true"}
           data-uvpa_error_message={@uvpa_error_message}
+          data-authenticator-attachment={authenticator_attachment}
           class={@class}
           title="Create a new account"
           disabled={@disabled}

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -124,7 +124,7 @@ defmodule WebauthnComponents.RegistrationComponent do
       data-check_uvpa_available={if @check_uvpa_available, do: "true"}
       data-uvpa_error_message={@uvpa_error_message}
       class={@class}
-      title="Create a new account"
+      title={@display_text}
       disabled={@disabled}
     >
       <span :if={@show_icon?} class="w-4 aspect-square opacity-70">

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -65,6 +65,7 @@ defmodule WebauthnComponents.RegistrationComponent do
   """
   use Phoenix.LiveComponent
   import WebauthnComponents.IconComponents
+  import WebauthnComponents.BaseComponents, only: [button: 1]
   alias WebauthnComponents.WebauthnUser
 
   def mount(socket) do
@@ -113,23 +114,24 @@ defmodule WebauthnComponents.RegistrationComponent do
     end
 
     ~H"""
-    <button
-      id={@id}
-      type="button"
-      phx-hook="RegistrationHook"
-      phx-target={@myself}
-      phx-click="register"
-      data-check_uvpa_available={if @check_uvpa_available, do: "true"}
-      data-uvpa_error_message={@uvpa_error_message}
-      class={@class}
-      title={@display_text}
-      disabled={@disabled}
-    >
-      <span :if={@show_icon?} class="w-4 aspect-square opacity-70">
-        <.icon type={@icon_type} />
-      </span>
-      <span><%= @display_text %></span>
-    </button>
+    <span>
+      <.button
+        id={@id}
+        phx-hook="RegistrationHook"
+        phx-target={@myself}
+        phx-click="register"
+        data-check_uvpa_available={if @check_uvpa_available, do: "true"}
+        data-uvpa_error_message={@uvpa_error_message}
+        class={@class}
+        title={@display_text}
+        disabled={@disabled}
+      >
+        <span :if={@show_icon?} class="w-4 aspect-square opacity-70">
+          <.icon type={@icon_type} />
+        </span>
+        <span><%= @display_text %></span>
+      </.button>
+    </span>
     """
   end
 

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -72,7 +72,6 @@ defmodule WebauthnComponents.RegistrationComponent do
       :ok,
       socket
       |> assign(:challenge, fn -> nil end)
-      |> assign_new(:id, fn -> "registration-component" end)
       |> assign_new(:class, fn -> "" end)
       |> assign_new(:timeout, fn -> 60_000 end)
       |> assign_new(:webauthn_user, fn -> nil end)
@@ -118,6 +117,11 @@ defmodule WebauthnComponents.RegistrationComponent do
           :platform -> :key
           :cross_platform -> :usb
         end
+      end)
+    end)
+    |> then(fn socket ->
+      assign_new(socket, :id, fn ->
+        "registration-component-#{socket.assigns.authenticator_attachment}"
       end)
     end)
     |> then(&{:ok, &1})

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -64,7 +64,6 @@ defmodule WebauthnComponents.RegistrationComponent do
   """
   use Phoenix.LiveComponent
   import WebauthnComponents.IconComponents
-  import WebauthnComponents.BaseComponents
   alias WebauthnComponents.WebauthnUser
 
   def mount(socket) do

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -129,26 +129,22 @@ defmodule WebauthnComponents.RegistrationComponent do
     end
 
     ~H"""
-    <div class="flex flex-col space-y-4">
-      <span>
-        <.button
-          id={@id}
-          phx-hook="RegistrationHook"
-          phx-target={@myself}
-          phx-click="register"
-          data-check_uvpa_available={if @check_uvpa_available, do: "true"}
-          data-uvpa_error_message={@uvpa_error_message}
-          class={@class}
-          title="Create a new account"
-          disabled={@disabled}
-        >
-          <span :if={@show_icon?} class="w-4 aspect-square opacity-70">
-            <.icon type={@icon_type} />
-          </span>
-          <span><%= @display_text %></span>
-        </.button>
+    <.button
+      id={@id}
+      phx-hook="RegistrationHook"
+      phx-target={@myself}
+      phx-click="register"
+      data-check_uvpa_available={if @check_uvpa_available, do: "true"}
+      data-uvpa_error_message={@uvpa_error_message}
+      class={@class}
+      title="Create a new account"
+      disabled={@disabled}
+    >
+      <span :if={@show_icon?} class="w-4 aspect-square opacity-70">
+        <.icon type={@icon_type} />
       </span>
-    </div>
+      <span><%= @display_text %></span>
+    </.button>
     """
   end
 

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -149,7 +149,7 @@ defmodule WebauthnComponents.RegistrationComponent do
           <span :if={@show_icon?} class="w-4 aspect-square opacity-70">
             <.icon type={icon_type} />
           </span>
-          <span><%= display_text %><%= @timeout %></span>
+          <span><%= display_text %></span>
         </.button>
       </span>
     </div>

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -103,27 +103,7 @@ defmodule WebauthnComponents.RegistrationComponent do
     socket
     |> assign(assigns)
     |> assign_new(:authenticator_attachment, fn -> :platform end)
-    |> then(fn socket ->
-      assign_new(socket, :display_text, fn ->
-        case socket.assigns.authenticator_attachment do
-          :platform -> "Sign Up With Passkey"
-          :cross_platform -> "Sign Up With Connected Device"
-        end
-      end)
-    end)
-    |> then(fn socket ->
-      assign_new(socket, :icon_type, fn ->
-        case socket.assigns.authenticator_attachment do
-          :platform -> :key
-          :cross_platform -> :usb
-        end
-      end)
-    end)
-    |> then(fn socket ->
-      assign_new(socket, :id, fn ->
-        "registration-component-#{socket.assigns.authenticator_attachment}"
-      end)
-    end)
+    |> assign_authenticator_attachment_dependant_assigns()
     |> then(&{:ok, &1})
   end
 
@@ -245,4 +225,28 @@ defmodule WebauthnComponents.RegistrationComponent do
     send(self(), {:invalid_event, event, payload})
     {:noreply, socket}
   end
+
+  defp assign_authenticator_attachment_dependant_assigns(socket) do
+    %{authenticator_attachment: authenticator_attachment} = socket.assigns
+
+    socket
+    |> assign_new(:id, fn -> default_id(authenticator_attachment) end)
+    |> assign_new(:display_text, fn -> default_display_text(authenticator_attachment) end)
+    |> assign_new(:icon_type, fn -> default_icon_type(authenticator_attachment) end)
+  end
+
+  defp default_id(authenticator_attachment) do
+    "registration-component-#{authenticator_attachment}"
+  end
+
+  defp default_display_text(:platform) do
+    "Sign Up With Passkey"
+  end
+
+  defp default_display_text(:cross_platform) do
+    "Sign Up With Connected Device"
+  end
+
+  defp default_icon_type(:platform), do: :key
+  defp default_icon_type(:cross_platform), do: :usb
 end

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -107,7 +107,7 @@ defmodule WebauthnComponents.RegistrationComponent do
     |> then(fn socket ->
       assign_new(socket, :display_text, fn ->
         case socket.assigns.authenticator_attachment do
-          :platform -> "Sign Up"
+          :platform -> "Sign Up With Passkey"
           :cross_platform -> "Sign Up With Connected Device"
         end
       end)

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -15,7 +15,6 @@ defmodule WebauthnComponents.RegistrationComponent do
   - `@app`: (**Required**) The name of your application or service. This is displayed to the user during registration.
   - `@authenticator_attachment` (Optional) The type of authenticator to use. Either `:platform` or `:cross_platform`. Defaults to `:platform`.
   - `@display_text` (Optional) The text displayed inside the "platform" button. Defaults to "Sign Up" if authenticator attachment is `:platform`, or "Sign Up With Connected Device" if `:cross_platform`.
-  - `@display_text_class` (Optional) CSS classes for the display text span element.
   - `@icon_type` (Optional) The icon displayed inside the button. Either `:key` or `:usb`. Defaults to `:key` if authenticator attachment is `:platform`, or `:usb` if `:cross_platform`.
   - `@show_icon?` (Optional) Controls visibility of the key icon. Defaults to `true`.
   - `@class` (Optional) CSS classes for overriding the default button style.
@@ -84,7 +83,6 @@ defmodule WebauthnComponents.RegistrationComponent do
       end)
       |> assign_new(:show_icon?, fn -> true end)
       |> assign_new(:relying_party, fn -> nil end)
-      |> assign_new(:display_text_class, fn -> nil end)
     }
   end
 
@@ -130,7 +128,7 @@ defmodule WebauthnComponents.RegistrationComponent do
       <span :if={@show_icon?} class="w-4 aspect-square opacity-70">
         <.icon type={@icon_type} />
       </span>
-      <span class={@display_text_class}><%= @display_text %></span>
+      <span><%= @display_text %></span>
     </button>
     """
   end

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -15,6 +15,8 @@ defmodule WebauthnComponents.RegistrationComponent do
   - `@app`: (**Required**) The name of your application or service. This is displayed to the user during registration.
   - `@authenticator_attachment` (Optional) The type of authenticator to use. Either `:platform` or `:cross_platform`. Defaults to `:platform`.
   - `@display_text` (Optional) The text displayed inside the "platform" button. Defaults to "Sign Up" if authenticator attachment is `:platform`, or "Sign Up With Connected Device" if `:cross_platform`.
+  - `@display_text_class` (Optional) CSS classes for the display text span element.
+  - `@icon_type` (Optional) The icon displayed inside the button. Either `:key` or `:usb`. Defaults to `:key` if authenticator attachment is `:platform`, or `:usb` if `:cross_platform`.
   - `@show_icon?` (Optional) Controls visibility of the key icon. Defaults to `true`.
   - `@class` (Optional) CSS classes for overriding the default button style.
   - `@disabled` (Optional) Set to `true` when the `SupportHook` indicates WebAuthn is not supported or enabled by the browser. Defaults to `false`.
@@ -82,6 +84,7 @@ defmodule WebauthnComponents.RegistrationComponent do
       end)
       |> assign_new(:show_icon?, fn -> true end)
       |> assign_new(:relying_party, fn -> nil end)
+      |> assign_new(:display_text_class, fn -> nil end)
     }
   end
 
@@ -127,7 +130,7 @@ defmodule WebauthnComponents.RegistrationComponent do
       <span :if={@show_icon?} class="w-4 aspect-square opacity-70">
         <.icon type={@icon_type} />
       </span>
-      <span><%= @display_text %></span>
+      <span class={@display_text_class}><%= @display_text %></span>
     </button>
     """
   end

--- a/lib/webauthn_components/registration_component.ex
+++ b/lib/webauthn_components/registration_component.ex
@@ -113,8 +113,9 @@ defmodule WebauthnComponents.RegistrationComponent do
     end
 
     ~H"""
-    <.button
+    <button
       id={@id}
+      type="button"
       phx-hook="RegistrationHook"
       phx-target={@myself}
       phx-click="register"
@@ -128,7 +129,7 @@ defmodule WebauthnComponents.RegistrationComponent do
         <.icon type={@icon_type} />
       </span>
       <span><%= @display_text %></span>
-    </.button>
+    </button>
     """
   end
 

--- a/priv/static/registration_hook.ts
+++ b/priv/static/registration_hook.ts
@@ -11,9 +11,7 @@ export const RegistrationHook = {
     }
 
     this.handleEvent("registration-challenge", (event) => {
-      if (
-        event.authenticatorAttachment == this.el.dataset.authenticatorAttachment
-      ) {
+      if (event.id == this.el.id) {
         this.handleRegistration(event, this);
       }
     });

--- a/priv/static/registration_hook.ts
+++ b/priv/static/registration_hook.ts
@@ -11,7 +11,9 @@ export const RegistrationHook = {
     }
 
     this.handleEvent("registration-challenge", (event) => {
-      if (event.authenticatorAttachment == this.el.dataset.authenticatorAttachment) {
+      if (
+        event.authenticatorAttachment == this.el.dataset.authenticatorAttachment
+      ) {
         this.handleRegistration(event, this);
       }
     });

--- a/priv/static/registration_hook.ts
+++ b/priv/static/registration_hook.ts
@@ -32,6 +32,7 @@ export const RegistrationHook = {
     try {
       const {
         attestation,
+        authenticatorAttachment,
         challenge,
         excludeCredentials,
         residentKey,
@@ -47,7 +48,7 @@ export const RegistrationHook = {
       const publicKey: PublicKeyCredentialCreationOptions = {
         attestation,
         authenticatorSelection: {
-          authenticatorAttachment: "platform",
+          authenticatorAttachment: authenticatorAttachment,
           residentKey: residentKey,
           requireResidentKey: requireResidentKey,
         },

--- a/priv/static/registration_hook.ts
+++ b/priv/static/registration_hook.ts
@@ -10,9 +10,11 @@ export const RegistrationHook = {
       });
     }
 
-    this.handleEvent("registration-challenge", (event) =>
-      this.handleRegistration(event, this)
-    );
+    this.handleEvent("registration-challenge", (event) => {
+      if (event.authenticatorAttachment == this.el.dataset.authenticatorAttachment) {
+        this.handleRegistration(event, this);
+      }
+    });
   },
   async checkUserVerifyingPlatformAuthenticatorAvailable(
     context,

--- a/templates/live_views/registration_live.ex
+++ b/templates/live_views/registration_live.ex
@@ -52,7 +52,12 @@ defmodule <%= inspect @web_pascal_case %>.RegistrationLive do
       |> Map.put(:name, email)
       |> Map.put(:display_name, email)
 
-    send_update(RegistrationComponent, id: "registration-component", webauthn_user: webauthn_user)
+    for authenticator_attachment <- [:platform, :cross_platform] do
+      send_update(RegistrationComponent,
+        id: "registration-component-#{authenticator_attachment}",
+        webauthn_user: webauthn_user
+      )
+    end
 
     {
       :noreply,

--- a/templates/live_views/registration_live.html.heex
+++ b/templates/live_views/registration_live.html.heex
@@ -16,12 +16,31 @@
     >
       <p>Create a <strong>new</strong> account:</p>
 
-      <.input type="email" field={form[:email]} label="Email" phx-debounce="250" autocomplete="username webauthn" />
+      <.input
+        type="email"
+        field={form[:email]}
+        label="Email"
+        phx-debounce="250"
+        autocomplete="username webauthn"
+      />
       <.live_component
+        :for={
+          {authenticator_attachment, display_text} <- [
+            platform: dpgettext("registration", "buttons", "Register using a passkey"),
+            cross_platform:
+              dpgettext(
+                "registration",
+                "buttons",
+                "Register using a passkey with an external device (e.g. phone, security key, etc.)"
+              )
+          ]
+        }
+        authenticator_attachment={authenticator_attachment}
+        display_text={display_text}
+        id={"registration-component-#{authenticator_attachment}"}
         disabled={@form.source.valid? == false}
         module={RegistrationComponent}
-        id="registration-component"
-        app={<%= inspect @app_pascal_case %>}
+        app={inspect(@app_pascal_case)}
         check_uvpa_available={false}
         class={[
           "bg-gray-200 hover:bg-gray-300 hover:text-black rounded transition",
@@ -30,7 +49,6 @@
           "disabled:cursor-not-allowed disabled:opacity-25"
         ]}
       />
-
 
       <.link navigate={~p"/sign-in"} class="underline">Sign into an existing account</.link>
     </fieldset>

--- a/test/webauthn_components/registration_component_test.exs
+++ b/test/webauthn_components/registration_component_test.exs
@@ -10,13 +10,14 @@ defmodule WebauthnComponents.RegistrationComponentTest do
     assigns = %{app: @app, id: @id}
     {:ok, view, _html} = live_isolated_component(RegistrationComponent, assigns)
     live_assign(view, app: assigns.app, id: assigns.id)
-    element = element(view, "##{assigns.id}")
+    element = element(view, "##{assigns.id}-platform")
     %{view: view, element: element, default_assigns: assigns}
   end
 
   describe "render/1" do
     test "returns element with id and phx hook", %{view: view} do
-      assert has_element?(view, "##{@id}[phx-hook='RegistrationHook']")
+      assert has_element?(view, "##{@id}-platform[phx-hook='RegistrationHook']")
+      assert has_element?(view, "##{@id}-cross-platform[phx-hook='RegistrationHook']")
     end
   end
 
@@ -25,14 +26,17 @@ defmodule WebauthnComponents.RegistrationComponentTest do
       %{default_assigns: default_assigns} = setup_attrs
       assigns = Map.merge(default_assigns, %{disabled: true})
       {:ok, view, _html} = live_isolated_component(RegistrationComponent, assigns)
-      assert has_element?(view, "##{assigns.id}[disabled]")
+      assert has_element?(view, "##{assigns.id}-platform[disabled]")
+      assert has_element?(view, "##{assigns.id}-cross-platform[disabled]")
     end
 
     test "is not `disabled` by default", setup_attrs do
       %{default_assigns: assigns} = setup_attrs
       {:ok, view, _html} = live_isolated_component(RegistrationComponent, assigns)
-      assert has_element?(view, "##{assigns.id}")
-      refute has_element?(view, "##{assigns.id}[disabled]")
+      assert has_element?(view, "##{assigns.id}-platform")
+      assert has_element?(view, "##{assigns.id}-cross-platform")
+      refute has_element?(view, "##{assigns.id}-platform[disabled]")
+      refute has_element?(view, "##{assigns.id}-cross-platform[disabled]")
     end
   end
 
@@ -50,8 +54,8 @@ defmodule WebauthnComponents.RegistrationComponentTest do
       assert clicked_element =~ "phx-click=\"register\""
 
       assert_push_event(view, "registration-challenge", %{
-        id: "registration-component",
-        user: ^webauthn_user
+        "id" => "registration-component",
+        "user" => ^webauthn_user
       })
     end
   end

--- a/test/webauthn_components/registration_component_test.exs
+++ b/test/webauthn_components/registration_component_test.exs
@@ -10,14 +10,13 @@ defmodule WebauthnComponents.RegistrationComponentTest do
     assigns = %{app: @app, id: @id}
     {:ok, view, _html} = live_isolated_component(RegistrationComponent, assigns)
     live_assign(view, app: assigns.app, id: assigns.id)
-    element = element(view, "##{assigns.id}-platform")
+    element = element(view, "##{assigns.id}")
     %{view: view, element: element, default_assigns: assigns}
   end
 
   describe "render/1" do
     test "returns element with id and phx hook", %{view: view} do
-      assert has_element?(view, "##{@id}-platform[phx-hook='RegistrationHook']")
-      assert has_element?(view, "##{@id}-cross-platform[phx-hook='RegistrationHook']")
+      assert has_element?(view, "##{@id}[phx-hook='RegistrationHook']")
     end
   end
 
@@ -26,17 +25,14 @@ defmodule WebauthnComponents.RegistrationComponentTest do
       %{default_assigns: default_assigns} = setup_attrs
       assigns = Map.merge(default_assigns, %{disabled: true})
       {:ok, view, _html} = live_isolated_component(RegistrationComponent, assigns)
-      assert has_element?(view, "##{assigns.id}-platform[disabled]")
-      assert has_element?(view, "##{assigns.id}-cross-platform[disabled]")
+      assert has_element?(view, "##{assigns.id}[disabled]")
     end
 
     test "is not `disabled` by default", setup_attrs do
       %{default_assigns: assigns} = setup_attrs
       {:ok, view, _html} = live_isolated_component(RegistrationComponent, assigns)
-      assert has_element?(view, "##{assigns.id}-platform")
-      assert has_element?(view, "##{assigns.id}-cross-platform")
-      refute has_element?(view, "##{assigns.id}-platform[disabled]")
-      refute has_element?(view, "##{assigns.id}-cross-platform[disabled]")
+      assert has_element?(view, "##{assigns.id}")
+      refute has_element?(view, "##{assigns.id}[disabled]")
     end
   end
 

--- a/test/webauthn_components/registration_component_test.exs
+++ b/test/webauthn_components/registration_component_test.exs
@@ -55,7 +55,8 @@ defmodule WebauthnComponents.RegistrationComponentTest do
 
       assert_push_event(view, "registration-challenge", %{
         "id" => "registration-component",
-        "user" => ^webauthn_user
+        "user" => ^webauthn_user,
+        "authenticatorAttachment" => "platform"
       })
     end
   end


### PR DESCRIPTION
# Overview

Resolves #87 (I think)

What problem is being solved by this branch?

Basically, when registering, we specify "platform" or "cross-platform". If using, e.g. YubiKey, then it must be "cross-platform".

We used to have "platform" hardcoded so it could not be worked around.

## Changes

I added an extra button to the RegistrationComponent, for cross-platform.

Default button label is "Sign Up With Connected Device" but it can be customized.

See this screenshot of platform and cross-platform registration buttons being rendered with custom labels.

<img width="754" height="485" alt="Screenshot 2025-08-31 210745" src="https://github.com/user-attachments/assets/b2ca56e8-9317-4d7c-8dc6-a9f15b575520" />

I made 1 cheeky extra change which was to remove some camelCase atoms (which cause compiler warnings, which is not pleasant). These atoms were simply map keys and that map was just being sent to the client (JS) so switching to string keys should cause no issues.

## Tests

Some broke, I fixed them.

## Collaborators

1. @type1fool
1. **more_collabs**
