### PR TITLE
Ignore `.expert` dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # The directory Mix will write compiled artifacts to.
 /_build/
 /.elixir_ls
+/.expert
 
 # If you run "mix test --cover", coverage assets end up here.
 /cover/


### PR DESCRIPTION
# Overview

The new official Elixir LSP, [Expert](https://github.com/elixir-lang/expert), has been launched. Its files need to be ignored so they're not inadvertently committed.

## Changes

- Ignore `/.expert` directory

## Tests

N/A

## Collaborators

1. @type1fool
