### PR TITLE
Make work with latest `mix phx.new`

### DIFF
--- a/lib/mix/tasks/wac.install.ex
+++ b/lib/mix/tasks/wac.install.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Wac.Install do
   alias Wac.Gen.Fixtures
   alias Wac.Gen.Javascript
   alias Wac.Gen.Components
-  alias Wac.Gen.AppHtml
+  alias Wac.Gen.RootHtml
   alias Wac.Gen.Misc
 
   @version Mix.Project.config()[:version]
@@ -104,8 +104,8 @@ defmodule Mix.Tasks.Wac.Install do
         if opts[:web] do
           Controllers.copy_templates(assigns)
           LiveViews.copy_templates(assigns)
-          AppHtml.update_app_html(assigns)
-          AppHtml.update_page_html(assigns)
+          RootHtml.update_root_html(assigns)
+          RootHtml.update_page_html(assigns)
           SessionHooks.copy_templates(assigns)
           Components.copy_templates(assigns)
 

--- a/lib/wac_gen/root_html.ex
+++ b/lib/wac_gen/root_html.ex
@@ -1,9 +1,9 @@
-defmodule Wac.Gen.AppHtml do
+defmodule Wac.Gen.RootHtml do
   @moduledoc false
 
-  def update_app_html(assigns) do
+  def update_root_html(assigns) do
     web_snake_case = Keyword.fetch!(assigns, :web_snake_case)
-    file_path = Path.join(["lib", web_snake_case, "components", "layouts", "app.html.heex"])
+    file_path = Path.join(["lib", web_snake_case, "components", "layouts", "root.html.heex"])
 
     modified_file_contents =
       file_path


### PR DESCRIPTION
# Overview

Make changes to `root.html.heex` instead of `app.html.heex`, which does not exist in latest phx versions.

## Collaborators

1. @peaceful-james 
